### PR TITLE
refactor: Replace deprecated `add` method with `push_error` in error …

### DIFF
--- a/abop-core/src/error/macros.rs
+++ b/abop-core/src/error/macros.rs
@@ -174,19 +174,6 @@ impl ErrorChain {
         self
     }
 
-    /// Add an error to the chain (alias for push_error to maintain compatibility)
-    ///
-    /// # Deprecated
-    /// This method is deprecated in favor of `push_error()` to avoid confusion
-    /// with the `std::ops::Add` trait. Use `push_error()` instead.
-    #[deprecated(
-        since = "0.1.0",
-        note = "Use `push_error()` instead to avoid trait confusion"
-    )]
-    pub fn add<E: std::fmt::Display>(self, error: E) -> Self {
-        self.push_error(error)
-    }
-
     /// Add a context message to the chain
     pub fn context(mut self, context: &str) -> Self {
         self.errors.push(context.to_string());
@@ -246,7 +233,7 @@ mod tests {
     fn test_error_chain() {
         let chain = ErrorChain::new()
             .context("Loading configuration")
-            .add(std::io::Error::new(
+            .push_error(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 "file not found",
             ))

--- a/abop-core/tests/error_macros_tests.rs
+++ b/abop-core/tests/error_macros_tests.rs
@@ -183,12 +183,12 @@ fn test_error_context_trait() {
 fn test_error_chain() {
     let chain = ErrorChain::new()
         .context("Loading application")
-        .add(std::io::Error::new(
+        .push_error(std::io::Error::new(
             std::io::ErrorKind::NotFound,
             "config.toml not found",
         ))
         .context("Configuration initialization failed")
-        .add("Database connection error");
+        .push_error("Database connection error");
 
     let error = chain.into_error();
     let error_string = error.to_string();
@@ -220,7 +220,7 @@ fn test_complex_error_scenario() {
             .map_err(|e| {
                 ErrorChain::new()
                     .context("Configuration loading")
-                    .add(e)
+                    .push_error(e)
                     .context("Application initialization failed")
                     .into_error()
             })?;

--- a/abop-gui/src/styling/material/components/selection/builder/components.rs
+++ b/abop-gui/src/styling/material/components/selection/builder/components.rs
@@ -29,39 +29,68 @@ pub struct Checkbox {
     pub(crate) animation_config: AnimationConfig,
 }
 
+// ============================================================================
+// Phase 1: Enhanced Trait Implementations for Checkbox
+// ============================================================================
+
+impl ErrorState for Checkbox {
+    fn has_error(&self) -> bool {
+        self.error_state
+    }
+    
+    fn set_error(&mut self, error: bool) {
+        self.error_state = error;
+    }
+}
+
+impl AnimatedWidget for Checkbox {
+    fn animation_config(&self) -> &AnimationConfig {
+        &self.animation_config
+    }
+    
+    fn set_animation_config(&mut self, config: AnimationConfig) {
+        self.animation_config = config;
+    }
+}
+
+impl EnhancedSelectionWidget<CheckboxState> for Checkbox {
+    fn set_state(&mut self, state: CheckboxState) {
+        self.state = state;
+    }
+    
+    fn toggle_if_binary(&mut self) -> Option<CheckboxState> {
+        let previous_state = self.state;
+        self.state = self.state.toggle();
+        Some(previous_state)
+    }
+}
+
 impl Checkbox {
-    /// Get the checkbox state
+    // Note: Basic accessors now provided by traits
+    // Keeping const versions for backwards compatibility
+    
+    /// Get the checkbox state (const version)
     #[must_use]
-    pub const fn state(&self) -> CheckboxState {
+    pub const fn state_const(&self) -> CheckboxState {
         self.state
     }
 
-    /// Get the component properties
+    /// Get the component properties (const version)
     #[must_use]
-    pub const fn props(&self) -> &ComponentProps {
+    pub const fn props_const(&self) -> &ComponentProps {
         &self.props
     }
 
-    /// Check if the checkbox is in error state
+    /// Check if the checkbox is in error state (const version)
     #[must_use]
-    pub const fn has_error(&self) -> bool {
+    pub const fn has_error_const(&self) -> bool {
         self.error_state
     }
 
-    /// Get the animation configuration
+    /// Get the animation configuration (const version)
     #[must_use]
-    pub const fn animation_config(&self) -> &AnimationConfig {
+    pub const fn animation_config_const(&self) -> &AnimationConfig {
         &self.animation_config
-    }
-
-    /// Set the checkbox state
-    pub fn set_state(&mut self, state: CheckboxState) {
-        self.state = state;
-    }
-
-    /// Set error state
-    pub fn set_error(&mut self, error: bool) {
-        self.error_state = error;
     }
 
     /// Check the checkbox
@@ -85,10 +114,9 @@ impl Checkbox {
         Ok(previous_state)
     }
 
-    /// Toggle the checkbox state
+    /// Toggle the checkbox state (enhanced version)
     pub fn toggle(&mut self) -> Result<(CheckboxState, CheckboxState), SelectionError> {
-        let previous_state = self.state;
-        self.state = self.state.toggle();
+        let previous_state = self.toggle_if_binary().unwrap_or(self.state);
         Ok((previous_state, self.state))
     }
 
@@ -128,7 +156,7 @@ impl Checkbox {
 
 impl PartialEq for Checkbox {
     fn eq(&self, other: &Self) -> bool {
-        self.state == other.state
+        self.state == other.state 
             && self.props == other.props
             && self.error_state == other.error_state
         // Note: animation_config is excluded from equality comparison
@@ -136,6 +164,42 @@ impl PartialEq for Checkbox {
 }
 
 impl Eq for Checkbox {}
+
+// ============================================================================
+// Phase 1: Enhanced Trait Implementations for Switch
+// ============================================================================
+
+impl ErrorState for Switch {
+    fn has_error(&self) -> bool {
+        self.error_state
+    }
+    
+    fn set_error(&mut self, error: bool) {
+        self.error_state = error;
+    }
+}
+
+impl AnimatedWidget for Switch {
+    fn animation_config(&self) -> &AnimationConfig {
+        &self.animation_config
+    }
+    
+    fn set_animation_config(&mut self, config: AnimationConfig) {
+        self.animation_config = config;
+    }
+}
+
+impl EnhancedSelectionWidget<SwitchState> for Switch {
+    fn set_state(&mut self, state: SwitchState) {
+        self.state = state;
+    }
+    
+    fn toggle_if_binary(&mut self) -> Option<SwitchState> {
+        let previous_state = self.state;
+        self.state = self.state.toggle();
+        Some(previous_state)
+    }
+}
 
 /// Material Design 3 Radio Button component (modern implementation)
 #[derive(Debug, Clone)]
@@ -252,6 +316,51 @@ where
 
 impl<T> Eq for Radio<T> where T: Clone + PartialEq + Eq + std::hash::Hash {}
 
+// ============================================================================
+// Phase 1: Enhanced Trait Implementations for Radio
+// ============================================================================
+
+impl<T> ErrorState for Radio<T>
+where
+    T: Clone + PartialEq + Eq + std::hash::Hash,
+{
+    fn has_error(&self) -> bool {
+        self.error_state
+    }
+    
+    fn set_error(&mut self, error: bool) {
+        self.error_state = error;
+    }
+}
+
+impl<T> AnimatedWidget for Radio<T>
+where
+    T: Clone + PartialEq + Eq + std::hash::Hash,
+{
+    fn animation_config(&self) -> &AnimationConfig {
+        &self.animation_config
+    }
+    
+    fn set_animation_config(&mut self, config: AnimationConfig) {
+        self.animation_config = config;
+    }
+}
+
+impl<T> EnhancedSelectionWidget<T> for Radio<T>
+where
+    T: Clone + PartialEq + Eq + std::hash::Hash,
+{
+    fn set_state(&mut self, state: T) {
+        self.value = state;
+    }
+    
+    fn toggle_if_binary(&mut self) -> Option<T> {
+        // Radio buttons don't toggle like binary states
+        // They are selected based on group selection
+        None
+    }
+}
+
 /// Material Design 3 Switch component (modern implementation)
 #[derive(Debug, Clone, Default)]
 pub struct Switch {
@@ -262,44 +371,36 @@ pub struct Switch {
 }
 
 impl Switch {
-    /// Get the switch state
+    // Note: Basic accessors now provided by traits
+    // Keeping const versions for backwards compatibility
+    
+    /// Get the switch state (const version)
     #[must_use]
-    pub const fn state(&self) -> SwitchState {
+    pub const fn state_const(&self) -> SwitchState {
         self.state
     }
 
-    /// Get the component properties
+    /// Get the component properties (const version)
     #[must_use]
-    pub const fn props(&self) -> &ComponentProps {
+    pub const fn props_const(&self) -> &ComponentProps {
         &self.props
     }
 
-    /// Check if the switch is in error state
+    /// Check if the switch is in error state (const version)
     #[must_use]
-    pub const fn has_error(&self) -> bool {
+    pub const fn has_error_const(&self) -> bool {
         self.error_state
     }
 
-    /// Get the animation configuration
+    /// Get the animation configuration (const version)
     #[must_use]
-    pub const fn animation_config(&self) -> &AnimationConfig {
+    pub const fn animation_config_const(&self) -> &AnimationConfig {
         &self.animation_config
     }
 
-    /// Set the switch state
-    pub fn set_state(&mut self, state: SwitchState) {
-        self.state = state;
-    }
-
-    /// Set error state
-    pub fn set_error(&mut self, error: bool) {
-        self.error_state = error;
-    }
-
-    /// Toggle the switch state
+    /// Toggle the switch state (enhanced version)
     pub fn toggle(&mut self) -> Result<(SwitchState, SwitchState), SelectionError> {
-        let previous_state = self.state;
-        self.state = self.state.toggle();
+        let previous_state = self.toggle_if_binary().unwrap_or(self.state);
         Ok((previous_state, self.state))
     }
 
@@ -324,7 +425,7 @@ impl Switch {
 
 impl PartialEq for Switch {
     fn eq(&self, other: &Self) -> bool {
-        self.state == other.state
+        self.state == other.state 
             && self.props == other.props
             && self.error_state == other.error_state
         // Note: animation_config is excluded from equality comparison
@@ -332,6 +433,42 @@ impl PartialEq for Switch {
 }
 
 impl Eq for Switch {}
+
+// ============================================================================
+// Phase 1: Enhanced Trait Implementations for Chip
+// ============================================================================
+
+impl ErrorState for Chip {
+    fn has_error(&self) -> bool {
+        self.error_state
+    }
+    
+    fn set_error(&mut self, error: bool) {
+        self.error_state = error;
+    }
+}
+
+impl AnimatedWidget for Chip {
+    fn animation_config(&self) -> &AnimationConfig {
+        &self.animation_config
+    }
+    
+    fn set_animation_config(&mut self, config: AnimationConfig) {
+        self.animation_config = config;
+    }
+}
+
+impl EnhancedSelectionWidget<ChipState> for Chip {
+    fn set_state(&mut self, state: ChipState) {
+        self.state = state;
+    }
+    
+    fn toggle_if_binary(&mut self) -> Option<ChipState> {
+        let previous_state = self.state;
+        self.state = self.state.toggle();
+        Some(previous_state)
+    }
+}
 
 /// Material Design 3 Chip component (modern implementation)
 #[derive(Debug, Clone, Default)]
@@ -345,15 +482,18 @@ pub struct Chip {
 }
 
 impl Chip {
+    // Note: Basic accessors now provided by traits
+    // Keeping const versions for backwards compatibility
+    
     /// Get the chip label
     #[must_use]
     pub fn label(&self) -> &str {
         &self.label
     }
 
-    /// Get the chip state
+    /// Get the chip state (const version)
     #[must_use]
-    pub const fn state(&self) -> ChipState {
+    pub const fn state_const(&self) -> ChipState {
         self.state
     }
 
@@ -363,31 +503,22 @@ impl Chip {
         self.variant
     }
 
-    /// Get the component properties
+    /// Get the component properties (const version)
     #[must_use]
-    pub const fn props(&self) -> &ComponentProps {
+    pub const fn props_const(&self) -> &ComponentProps {
         &self.props
     }
 
-    /// Check if the chip is in error state
+    /// Check if the chip is in error state (const version)
     #[must_use]
-    pub const fn has_error(&self) -> bool {
+    pub const fn has_error_const(&self) -> bool {
         self.error_state
     }
 
-    /// Get the animation configuration
+    /// Get the animation configuration (const version)
     #[must_use]
-    pub const fn animation_config(&self) -> &AnimationConfig {
+    pub const fn animation_config_const(&self) -> &AnimationConfig {
         &self.animation_config
-    }
-
-    /// Set the chip state
-    pub fn set_state(&mut self, state: ChipState) {
-        self.state = state;
-    }
-    /// Set error state
-    pub fn set_error(&mut self, error: bool) {
-        self.error_state = error;
     }
 
     /// Select the chip
@@ -404,10 +535,9 @@ impl Chip {
         Ok(previous_state)
     }
 
-    /// Toggle the chip selection state
+    /// Toggle the chip selection state (enhanced version)
     pub fn toggle(&mut self) -> Result<(ChipState, ChipState), SelectionError> {
-        let previous_state = self.state;
-        self.state = self.state.toggle();
+        let previous_state = self.toggle_if_binary().unwrap_or(self.state);
         Ok((previous_state, self.state))
     }
 
@@ -432,8 +562,8 @@ impl Chip {
 impl PartialEq for Chip {
     fn eq(&self, other: &Self) -> bool {
         self.label == other.label
-            && self.state == other.state
             && self.variant == other.variant
+            && self.state == other.state
             && self.props == other.props
             && self.error_state == other.error_state
         // Note: animation_config is excluded from equality comparison
@@ -469,23 +599,13 @@ impl SelectionWidget<CheckboxState> for Checkbox {
 
 impl StatefulWidget<CheckboxState> for Checkbox {
     fn update_state(&mut self, new_state: CheckboxState) -> Result<(), SelectionError> {
-        self.state = new_state;
+        self.set_state(new_state);
         Ok(())
     }
 
     fn transition_to(&mut self, new_state: CheckboxState) -> Result<CheckboxState, SelectionError> {
-        self.state = new_state;
-        Ok(self.state)
-    }
-}
-
-impl AnimatedWidget for Checkbox {
-    fn animation_config(&self) -> &AnimationConfig {
-        &self.animation_config
-    }
-
-    fn set_animation_config(&mut self, config: AnimationConfig) {
-        self.animation_config = config;
+        self.update_state(new_state)?;
+        Ok(self.state())
     }
 }
 
@@ -512,23 +632,13 @@ impl SelectionWidget<SwitchState> for Switch {
 
 impl StatefulWidget<SwitchState> for Switch {
     fn update_state(&mut self, new_state: SwitchState) -> Result<(), SelectionError> {
-        self.state = new_state;
+        self.set_state(new_state);
         Ok(())
     }
 
     fn transition_to(&mut self, new_state: SwitchState) -> Result<SwitchState, SelectionError> {
-        self.state = new_state;
-        Ok(self.state)
-    }
-}
-
-impl AnimatedWidget for Switch {
-    fn animation_config(&self) -> &AnimationConfig {
-        &self.animation_config
-    }
-
-    fn set_animation_config(&mut self, config: AnimationConfig) {
-        self.animation_config = config;
+        self.update_state(new_state)?;
+        Ok(self.state())
     }
 }
 
@@ -580,23 +690,13 @@ impl SelectionWidget<ChipState> for Chip {
 
 impl StatefulWidget<ChipState> for Chip {
     fn update_state(&mut self, new_state: ChipState) -> Result<(), SelectionError> {
-        self.state = new_state;
+        self.set_state(new_state);
         Ok(())
     }
 
     fn transition_to(&mut self, new_state: ChipState) -> Result<ChipState, SelectionError> {
-        self.state = new_state;
-        Ok(self.state)
-    }
-}
-
-impl AnimatedWidget for Chip {
-    fn animation_config(&self) -> &AnimationConfig {
-        &self.animation_config
-    }
-
-    fn set_animation_config(&mut self, config: AnimationConfig) {
-        self.animation_config = config;
+        self.update_state(new_state)?;
+        Ok(self.state())
     }
 }
 

--- a/abop-gui/src/styling/material/components/selection/chip/view.rs
+++ b/abop-gui/src/styling/material/components/selection/chip/view.rs
@@ -5,7 +5,7 @@
 //! use cases such as basic view, toggle view, and filter chip view.
 
 use super::super::builder::Chip;
-use super::super::common::{ChipState, ComponentSize};
+use super::super::common::{ChipState, ComponentSize, SelectionWidget};
 use crate::styling::material::colors::MaterialColors;
 use crate::styling::material::components::selection_style::{
     SelectionSize as LegacySelectionSize, SelectionStyleBuilder, SelectionVariant,

--- a/abop-gui/src/styling/material/components/selection/radio.rs
+++ b/abop-gui/src/styling/material/components/selection/radio.rs
@@ -274,19 +274,7 @@ where
 // Trait Implementations
 // ============================================================================
 // Note: SelectionWidget implementation is in builder/components.rs to avoid conflicts
-
-impl<T> AnimatedWidget for Radio<T>
-where
-    T: Clone + PartialEq + Eq + std::hash::Hash,
-{
-    fn animation_config(&self) -> &AnimationConfig {
-        &self.animation_config
-    }
-
-    fn set_animation_config(&mut self, config: AnimationConfig) {
-        self.animation_config = config;
-    }
-}
+// Note: AnimatedWidget implementation is provided via EnhancedSelectionWidget trait
 
 // ============================================================================
 // Convenience Functions

--- a/abop-gui/src/styling/material/components/selection/tests/basic_functionality.rs
+++ b/abop-gui/src/styling/material/components/selection/tests/basic_functionality.rs
@@ -19,8 +19,9 @@ use super::fixtures::{
 };
 use crate::styling::material::components::selection::builder::ComponentBuilder;
 use crate::styling::material::components::selection::{
-    ChipBuilder, ChipState, ChipVariant, ComponentSize, SelectionWidget,
+ ChipBuilder, ChipState, ChipVariant, ComponentSize,
 };
+use crate::styling::material::components::selection::common::{SelectionWidget, EnhancedSelectionWidget};
 
 #[cfg(test)]
 mod chip_creation_tests {

--- a/abop-gui/src/styling/material/components/selection/tests/builder_patterns.rs
+++ b/abop-gui/src/styling/material/components/selection/tests/builder_patterns.rs
@@ -8,7 +8,9 @@ use crate::styling::material::components::selection::builder::patterns::Componen
 use crate::styling::material::components::selection::{
     ChipBuilder, ChipState, ChipVariant, ComponentSize,
 };
-
+use crate::styling::material::components::selection::common::{
+    SelectionWidget
+};
 #[cfg(test)]
 mod builder_api_tests {
     use super::*;

--- a/abop-gui/src/styling/material/components/selection/tests/checkbox_tests.rs
+++ b/abop-gui/src/styling/material/components/selection/tests/checkbox_tests.rs
@@ -1,5 +1,8 @@
 //! Comprehensive tests for the modern Checkbox component
 
+use crate::styling::material::components::selection::common::{
+    AnimatedWidget, ErrorState,
+};
 use crate::styling::material::components::selection::{
     builder::{Checkbox, CheckboxBuilder, ComponentBuilder, ConditionalBuilder},
     checkbox::{checkbox_from_bool, checked_checkbox, indeterminate_checkbox, unchecked_checkbox},

--- a/abop-gui/src/styling/material/components/selection/tests/chip_test_helpers.rs
+++ b/abop-gui/src/styling/material/components/selection/tests/chip_test_helpers.rs
@@ -6,6 +6,7 @@
 use super::fixtures::test_data::ALL_CHIP_VARIANTS;
 use crate::styling::material::components::selection::builder::ComponentBuilder;
 use crate::styling::material::components::selection::chip::core::MAX_CHIP_LABEL_LENGTH;
+use crate::styling::material::components::selection::common::SelectionWidget;
 use crate::styling::material::components::selection::{
     Chip, ChipBuilder, ChipCollection, ChipCollectionBuilder, ChipSelectionMode, ChipState,
     ChipVariant, ComponentSize, SelectionError,

--- a/abop-gui/src/styling/material/components/selection/tests/fixtures/assertion_helpers.rs
+++ b/abop-gui/src/styling/material/components/selection/tests/fixtures/assertion_helpers.rs
@@ -4,8 +4,9 @@
 //! chip testing more expressive and provide better error messages.
 
 use super::test_data::*;
+use crate::styling::material::components::selection::common::{SelectionWidget, SelectionError};
 use crate::styling::material::components::selection::{
-    Chip, ChipCollection, ChipSelectionMode, ChipState, ChipVariant, ComponentSize, SelectionError,
+    Chip, ChipCollection, ChipSelectionMode, ChipState, ChipVariant, ComponentSize,
 };
 
 // ============================================================================


### PR DESCRIPTION
…chain and update related tests; enhance selection components with new trait implementations and improve test organization