### PR TITLE
refactor: Update logging for unknown metadata keys and enhance switch…

### DIFF
--- a/abop-gui/src/styling/material/components/selection/common.rs
+++ b/abop-gui/src/styling/material/components/selection/common.rs
@@ -361,8 +361,9 @@ impl ComponentProps {
         } else {
             // Allow unknown keys for extensibility but warn in debug builds
             #[cfg(debug_assertions)]
-            eprintln!(
-                "Warning: Unknown metadata key '{key_string}'. Consider using predefined constants."
+            log::warn!(
+                "Unknown metadata key '{}'. Consider using predefined constants.", 
+                key_string
             );
             self.metadata.insert(key_string, value.into());
         }

--- a/abop-gui/src/styling/material/components/selection/tests/switch_tests.rs
+++ b/abop-gui/src/styling/material/components/selection/tests/switch_tests.rs
@@ -165,9 +165,12 @@ mod integration_tests {
         let state = switch.state();
         assert_eq!(state, SwitchState::On);
 
-        // Test that we can recreate switch with same state
+        // Test that we can recreate switch with same configuration
+        // (Note: Switch::new only preserves state, not label/size)
         let recreated = Switch::new(state);
 
         assert_eq!(recreated.state(), switch.state());
+        // Note: The recreated switch will have default properties (no label, medium size)
+        // This is expected behavior for Switch::new() - use SwitchBuilder for full config
     }
 }


### PR DESCRIPTION
… test comments for clarity

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the logging mechanism for unknown metadata keys from using `eprintln!` to `log::warn!` and enhance the switch test comments to clarify the behavior when recreating a switch.

### Why are these changes being made?

The logging change improves the logging strategy by allowing different log levels and outputs to be managed more consistently within the application. Enhancements in the test commentary clarify the expectations for the switch state recreation mechanism and document the limitations of the `Switch::new` method, promoting better understanding for future maintenance and feature extension.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->